### PR TITLE
Handle missing null terminator for descriptor

### DIFF
--- a/usb/util.py
+++ b/usb/util.py
@@ -311,7 +311,10 @@ def get_string(dev, index, langid = None):
                 index,
                 langid
             )
+    part = buf[2:buf[0]]
+        if part[-1] != 0:
+            part.append(0)
     if hexversion >= 0x03020000:
-        return buf[2:buf[0]].tobytes().decode('utf-16-le')
+        return part.tobytes().decode('utf-16-le')
     else:
-        return buf[2:buf[0]].tostring().decode('utf-16-le')
+        return part.tostring().decode('utf-16-le')


### PR DESCRIPTION
I have found that certain device vendors provide invalid device descriptors that are missing a null terminator. In that case, this library crashes during the call to decode.

This provides a quick fix for that situation.